### PR TITLE
Fix copying mixup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,12 +69,12 @@ gulp.task('copy-uswds-fonts', () => {
 });
 
 gulp.task('copy-uswds-images', () => {
-  return gulp.src(`${uswds}/js/**/**`)
+  return gulp.src(`${uswds}/img/**/**`)
   .pipe(gulp.dest(`${IMG_DEST}`));
 });
 
 gulp.task('copy-uswds-js', () => {
-  return gulp.src(`${uswds}/img/**/**`)
+  return gulp.src(`${uswds}/js/**/**`)
   .pipe(gulp.dest(`${JS_DEST}`));
 });
 


### PR DESCRIPTION
The gulpfile was copying images to the javascript directory and javascript to the images directory for some reason. I implemented a simple fix, assuming it wasn't intentional.