### PR TITLE
Use Dart Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # USWDS Gulp pipeline for copying assets and compiling Sass
+
 A simple [Gulp 4.0](https://gulpjs.com/) workflow for transforming USWDS Sass into browser-readable CSS.
 
 ## Requirements
+
 You'll need to be familiar with the command line.
 
 You'll need [node](https://nodejs.org/en/download/) and [npm](https://www.npmjs.com/get-npm).
 
 You'll need to install the following packages via `npm`:
+
 - autoprefixer
-- css-mqpacker
 - cssnano
+- fibers
 - gulp@^4.0.0
 - gulp-notify
 - gulp-postcss
@@ -18,10 +21,13 @@ You'll need to install the following packages via `npm`:
 - gulp-sass
 - gulp-sourcemaps
 - path
+- postcss-sort-media-queries
+- sass
 - uswds@^2.0.0
 - uswds-gulp@github:uswds/uswds-gulp
 
 ## Installation
+
 If you've never installed Gulp, you'll need to install the Gulp command line interface:
 
 ```
@@ -31,10 +37,11 @@ npm install gulp-cli -g
 Add all the required dependencies at once with following command from your project's root directory:
 
 ```
-npm install autoprefixer css-mqpacker cssnano gulp@^4.0.0 gulp-notify gulp-postcss gulp-rename gulp-replace gulp-sass gulp-sourcemaps path uswds@latest uswds-gulp@github:uswds/uswds-gulp --save-dev
+npm install autoprefixer cssnano fibers gulp@^4.0.0 gulp-notify gulp-postcss gulp-rename gulp-replace gulp-sass gulp-sourcemaps path postcss-sort-media-queries sass uswds@latest uswds-gulp@github:uswds/uswds-gulp --save-dev
 ```
 
 ## Usage
+
 **If you don't already have a project gulpfile,** copy the `gulpfile.js` to your current directory (the project root):
 
 ```
@@ -49,28 +56,27 @@ OR
 cp node_modules/uswds-gulp/gulpfile.js gulpfile-uswds.js
 ```
 
-- - -
+---
 
 Open `gulpfile.js` in a text editor. In the `Paths` section, set the following constants with the proper paths. Don't use trailing slashes in the paths. All paths should be relative to the project root.
 
-  - `PROJECT_SASS_SRC`: The directory where we'll save your USWDS settings files and the project's custom Sass.
-  - `IMG_DEST`: The directory where we'll save the USWDS images
-  - `FONTS_DEST`: The directory where we'll save the USWDS fonts
-  - `JS_DEST`: The directory where we'll save the USWDS javascript
-  - `CSS_DEST`: The destination of the final, compiled CSS
+- `PROJECT_SASS_SRC`: The directory where we'll save your USWDS settings files and the project's custom Sass.
+- `IMG_DEST`: The directory where we'll save the USWDS images
+- `FONTS_DEST`: The directory where we'll save the USWDS fonts
+- `JS_DEST`: The directory where we'll save the USWDS javascript
+- `CSS_DEST`: The destination of the final, compiled CSS
 
-- - -
+---
 
 Save `gulpfile.js` with these updated paths.
 
-- - -
+---
 
 Initialize your USWDS project. Initialization does the following:
 
-  - Copies settings files and the USWDS base Sass file to your project Sass directory
-  - Copies images, fonts, and javascript files to the directories you set above
-  - Compiles the USWDS Sass into a usable CSS file, called `styles.css` by default
-
+- Copies settings files and the USWDS base Sass file to your project Sass directory
+- Copies images, fonts, and javascript files to the directories you set above
+- Compiles the USWDS Sass into a usable CSS file, called `styles.css` by default
 
 Intitialize your USWDS project by running the following command:
 
@@ -78,7 +84,7 @@ Intitialize your USWDS project by running the following command:
 gulp init
 ```
 
-- - -
+---
 
 Edit your USWDS settings in the new settings files and add custom Sass to the new `_uswds-theme-custom-styles.scss` file. Watch these files and compile any changes with
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,19 +11,22 @@ USWDS SASS GULPFILE
 ----------------------------------------
 */
 
-var autoprefixer  = require('autoprefixer');
-var autoprefixerOptions = require('./node_modules/uswds-gulp/config/browsers');
-var cssnano       = require('cssnano');
-var gulp          = require('gulp');
-var mqpacker      = require('css-mqpacker');
-var path          = require('path');
-var pkg           = require('./node_modules/uswds/package.json');
-var postcss       = require('gulp-postcss');
-var rename        = require('gulp-rename');
-var replace       = require('gulp-replace');
-var sass          = require('gulp-sass');
-var sourcemaps    = require('gulp-sourcemaps');
-var uswds         = require('./node_modules/uswds-gulp/config/uswds');
+const autoprefixer = require("autoprefixer");
+const autoprefixerOptions = require("./node_modules/uswds-gulp/config/browsers");
+const cssnano = require("cssnano");
+const Fiber = require("fibers");
+const gulp = require("gulp");
+const path = require("path");
+const pkg = require("./node_modules/uswds/package.json");
+const postcss = require("gulp-postcss");
+const rename = require("gulp-rename");
+const replace = require("gulp-replace");
+const sass = require("gulp-sass");
+const sortMQ = require("postcss-sort-media-queries");
+const sourcemaps = require("gulp-sourcemaps");
+const uswds = require("./node_modules/uswds-gulp/config/uswds");
+
+sass.compiler = require("sass");
 
 /*
 ----------------------------------------
@@ -37,24 +40,24 @@ PATHS
 */
 
 // Project Sass source directory
-const PROJECT_SASS_SRC = './path/to/project/sass';
+const PROJECT_SASS_SRC = "./path/to/project/sass";
 
 // Images destination
-const IMG_DEST = './path/to/images/destination';
+const IMG_DEST = "./path/to/images/destination";
 
 // Fonts destination
-const FONTS_DEST = './path/to/fonts/destination';
+const FONTS_DEST = "./path/to/fonts/destination";
 
 // Javascript destination
-const JS_DEST = './path/to/js/destination';
+const JS_DEST = "./path/to/js/destination";
 
 // Compiled CSS destination
-const CSS_DEST = './path/to/css/destination';
+const CSS_DEST = "./path/to/css/destination";
 
 // Site CSS destination
 // Like the _site/assets/css directory in Jekyll, if necessary.
 // If using, uncomment line 112
-const SITE_CSS_DEST = './path/to/site/css/destination';
+const SITE_CSS_DEST = "./path/to/site/css/destination";
 
 /*
 ----------------------------------------
@@ -62,69 +65,71 @@ TASKS
 ----------------------------------------
 */
 
-gulp.task('copy-uswds-setup', () => {
-  return gulp.src(`${uswds}/scss/theme/**/**`)
-  .pipe(gulp.dest(`${PROJECT_SASS_SRC}`));
+gulp.task("copy-uswds-setup", () => {
+  return gulp
+    .src(`${uswds}/scss/theme/**/**`)
+    .pipe(gulp.dest(`${PROJECT_SASS_SRC}`));
 });
 
-gulp.task('copy-uswds-fonts', () => {
-  return gulp.src(`${uswds}/fonts/**/**`)
-  .pipe(gulp.dest(`${FONTS_DEST}`));
+gulp.task("copy-uswds-fonts", () => {
+  return gulp.src(`${uswds}/fonts/**/**`).pipe(gulp.dest(`${FONTS_DEST}`));
 });
 
-gulp.task('copy-uswds-images', () => {
-  return gulp.src(`${uswds}/img/**/**`)
-  .pipe(gulp.dest(`${IMG_DEST}`));
+gulp.task("copy-uswds-images", () => {
+  return gulp.src(`${uswds}/img/**/**`).pipe(gulp.dest(`${IMG_DEST}`));
 });
 
-gulp.task('copy-uswds-js', () => {
-  return gulp.src(`${uswds}/js/**/**`)
-  .pipe(gulp.dest(`${JS_DEST}`));
+gulp.task("copy-uswds-js", () => {
+  return gulp.src(`${uswds}/js/**/**`).pipe(gulp.dest(`${JS_DEST}`));
 });
 
-gulp.task('build-sass', function(done) {
+gulp.task("build-sass", function(done) {
   var plugins = [
     // Autoprefix
     autoprefixer(autoprefixerOptions),
     // Pack media queries
-    mqpacker({ sort: true }),
+    sortMQ({ sort: "mobile-first" })
     // Minify
-    cssnano(({ autoprefixer: { browsers: autoprefixerOptions }}))
+    cssnano({ autoprefixer: { browsers: autoprefixerOptions } })
   ];
-  return gulp.src([
-      `${PROJECT_SASS_SRC}/*.scss`
-    ])
-    .pipe(sourcemaps.init({ largeFile: true }))
-    .pipe(sass({
-        includePaths: [
-          `${PROJECT_SASS_SRC}`,
-          `${uswds}/scss`,
-          `${uswds}/scss/packages`,
-        ]
-      }))
-    .pipe(replace(
-      /\buswds @version\b/g,
-      'based on uswds v' + pkg.version
-    ))
-    .pipe(postcss(plugins))
-    .pipe(sourcemaps.write('.'))
-    // uncomment the next line if necessary for Jekyll to build properly
-    //.pipe(gulp.dest(`${SITE_CSS_DEST}`))
-    .pipe(gulp.dest(`${CSS_DEST}`));
+  return (
+    gulp
+      .src([`${PROJECT_SASS_SRC}/*.scss`])
+      .pipe(sourcemaps.init({ largeFile: true }))
+      .pipe(
+        sass({
+          fiber: Fiber,
+          includePaths: [
+            `${PROJECT_SASS_SRC}`,
+            `${uswds}/scss`,
+            `${uswds}/scss/packages`
+          ]
+        })
+      )
+      .pipe(replace(/\buswds @version\b/g, "based on uswds v" + pkg.version))
+      .pipe(postcss(plugins))
+      .pipe(sourcemaps.write("."))
+      // uncomment the next line if necessary for Jekyll to build properly
+      //.pipe(gulp.dest(`${SITE_CSS_DEST}`))
+      .pipe(gulp.dest(`${CSS_DEST}`))
+  );
 });
 
-gulp.task('init', gulp.series(
-  'copy-uswds-setup',
-  'copy-uswds-fonts',
-  'copy-uswds-images',
-  'copy-uswds-js',
-  'build-sass',
-));
+gulp.task(
+  "init",
+  gulp.series(
+    "copy-uswds-setup",
+    "copy-uswds-fonts",
+    "copy-uswds-images",
+    "copy-uswds-js",
+    "build-sass"
+  )
+);
 
-gulp.task('watch-sass', function () {
-  gulp.watch(`${PROJECT_SASS_SRC}/**/*.scss`, gulp.series('build-sass'));
+gulp.task("watch-sass", function() {
+  gulp.watch(`${PROJECT_SASS_SRC}/**/*.scss`, gulp.series("build-sass"));
 });
 
-gulp.task('watch', gulp.series('build-sass', 'watch-sass'));
+gulp.task("watch", gulp.series("build-sass", "watch-sass"));
 
-gulp.task('default', gulp.series('watch'));
+gulp.task("default", gulp.series("watch"));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,7 @@ gulp.task("build-sass", function(done) {
     // Autoprefix
     autoprefixer(autoprefixerOptions),
     // Pack media queries
-    sortMQ({ sort: "mobile-first" })
+    sortMQ({ sort: "mobile-first" }),
     // Minify
     cssnano({ autoprefixer: { browsers: autoprefixerOptions } })
   ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "uswds-gulp",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds-gulp",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "A gulp workflow for USWDS",
   "main": "index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/uswds/uswds-gulp#readme",
   "peerDependencies": {
     "autoprefixer": "^9.6.1",
-    "css-mqpacker": "^7.0.0",
     "cssnano": "^4.1.10",
+    "fibers": "^4.0.2",
     "gulp": "^4.0.2",
     "gulp-postcss": "^8.0.0",
     "gulp-rename": "^1.4.0",
@@ -29,6 +29,8 @@
     "gulp-sass": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",
     "path": "^0.12.7",
+    "postcss-sort-media-queries": "^1.0.15",
+    "sass": "^1.25.0",
     "uswds": "^2.4.0"
   }
 }


### PR DESCRIPTION
**Updates the workflow to use Dart Sass.** This release integrates Dart Sass into the compile workflow. This replaces the `node-sass`/`libsass` implementation built into `gulp-sass` and updates the dependencies to enable fast compiles.

**Uses a maintained media query sorter.** We're now using `postcss-sort-media-queries` to replace a solution that is no longer maintained.