### PR TITLE
USWDS-3450: Move supported browsers to browserslist config.

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,5 @@
+# Supported browsers
+> 2%
+last 2 versions
+IE 11
+not dead

--- a/config/browsers.js
+++ b/config/browsers.js
@@ -1,5 +1,0 @@
-module.exports = [
-  '> 1%',
-  'Last 2 versions',
-  'IE 11',
-];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ USWDS SASS GULPFILE
 */
 
 const autoprefixer = require("autoprefixer");
-const autoprefixerOptions = require("./node_modules/uswds-gulp/config/browsers");
 const csso = require("postcss-csso");
 const gulp = require("gulp");
 const pkg = require("./node_modules/uswds/package.json");
@@ -82,9 +81,12 @@ gulp.task("copy-uswds-js", () => {
 gulp.task("build-sass", function(done) {
   var plugins = [
     // Autoprefix
-    autoprefixer(autoprefixerOptions),
+    autoprefixer({
+      cascade: false,
+      grid: true
+    }),
     // Minify
-    csso({ forceMediaMerge: false })
+    csso({ forceMediaMerge: false }),
   ];
   return (
     gulp

--- a/package.json
+++ b/package.json
@@ -8,12 +8,6 @@
     "init": "gulp init",
     "watch": "gulp watch"
   },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "ie 11",
-    "not dead"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/uswds/uswds-gulp.git"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "init": "gulp init",
     "watch": "gulp watch"
   },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "ie 11",
+    "not dead"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/uswds/uswds-gulp.git"


### PR DESCRIPTION
## Needs testing

Based on https://github.com/uswds/uswds/issues/3450

- Remove browsers.js
- Move supported browser settings to package.json under `browserslist`