### PR TITLE
USWDS - README: Update README with note on ZSH syntax error #19.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Add all the required dependencies at once with following command from your proje
 npm install autoprefixer gulp@^4.0.2 gulp-replace sass gulp-sass gulp-sourcemaps gulp-postcss postcss-csso uswds@latest uswds-gulp@github:uswds/uswds-gulp --save-dev
 ```
 
+>Note: If you're using ZSH you'll need to wrap gulp in quotes `"gulp@^4.0.2"`.
+> Otherwise you'll get an error that says `zsh: no matches found: gulp@^4.0.2`.
+
 ## Usage
 
 **If you don't already have a project gulpfile,** copy the `gulpfile.js` to your current directory (the project root):

--- a/README.md
+++ b/README.md
@@ -32,11 +32,8 @@ npm install gulp-cli -g
 Add all the required dependencies at once with following command from your project's root directory:
 
 ```bash
-npm install autoprefixer gulp@^4.0.2 gulp-replace sass gulp-sass gulp-sourcemaps gulp-postcss postcss-csso uswds@latest uswds-gulp@github:uswds/uswds-gulp --save-dev
+npm install autoprefixer gulp gulp-replace sass gulp-sass gulp-sourcemaps gulp-postcss postcss-csso uswds uswds-gulp@github:uswds/uswds-gulp --save-dev
 ```
-
->Note: If you're using ZSH you'll need to wrap gulp in quotes `"gulp@^4.0.2"`.
-> Otherwise you'll get an error that says `zsh: no matches found: gulp@^4.0.2`.
 
 ## Usage
 


### PR DESCRIPTION
Added the following note to README regarding a potential syntax error for ZSH users. This issue was first reported in #19.

>Note: If you're using ZSH you'll need to wrap gulp in quotes `"gulp@^4.0.2"`.
> Otherwise you'll get an error that says `zsh: no matches found: gulp@^4.0.2`.
