### PR TITLE
change import to support gulp-sass 5.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,15 +17,12 @@ const gulp = require("gulp");
 const pkg = require("./node_modules/uswds/package.json");
 const postcss = require("gulp-postcss");
 const replace = require("gulp-replace");
-const sass = require("gulp-sass");
+const sass = require("gulp-sass")(require('sass'));
 const sourcemaps = require("gulp-sourcemaps");
 const uswds = require("./node_modules/uswds-gulp/config/uswds");
 const del = require('del');
 const svgSprite = require('gulp-svg-sprite');
 const rename = require('gulp-rename');
-
-sass.compiler = require("sass");
-
 /*
 ----------------------------------------
 PATHS


### PR DESCRIPTION
In gulp-sass 5.0 Instead of setting a compiler prop on the gulp-sass instance, you pass the compiler into a function call when instantiating gulp-sass. See https://www.npmjs.com/package/gulp-sass#migrating-to-version-5

This will likely remove support for earlier gulp-sass versions.