### PR TITLE
USWDS - SASS: Update gulp-sass import

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,14 +17,13 @@ const gulp = require("gulp");
 const pkg = require("./node_modules/uswds/package.json");
 const postcss = require("gulp-postcss");
 const replace = require("gulp-replace");
-const sass = require("gulp-sass");
+const sass = require("gulp-sass")(require("sass"));
 const sourcemaps = require("gulp-sourcemaps");
 const uswds = require("./node_modules/uswds-gulp/config/uswds");
 const del = require('del');
 const svgSprite = require('gulp-svg-sprite');
 const rename = require('gulp-rename');
 
-sass.compiler = require("sass");
 
 /*
 ----------------------------------------

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,10 +20,9 @@ const replace = require("gulp-replace");
 const sass = require("gulp-sass")(require("sass"));
 const sourcemaps = require("gulp-sourcemaps");
 const uswds = require("./node_modules/uswds-gulp/config/uswds");
-const del = require('del');
-const svgSprite = require('gulp-svg-sprite');
-const rename = require('gulp-rename');
-
+const del = require("del");
+const svgSprite = require("gulp-svg-sprite");
+const rename = require("gulp-rename");
 
 /*
 ----------------------------------------
@@ -80,12 +79,12 @@ gulp.task("copy-uswds-js", () => {
   return gulp.src(`${uswds}/js/**/**`).pipe(gulp.dest(`${JS_DEST}`));
 });
 
-gulp.task("build-sass", function(done) {
+gulp.task("build-sass", function (done) {
   var plugins = [
     // Autoprefix
     autoprefixer({
       cascade: false,
-      grid: true
+      grid: true,
     }),
     // Minify
     csso({ forceMediaMerge: false }),
@@ -99,8 +98,8 @@ gulp.task("build-sass", function(done) {
           includePaths: [
             `${PROJECT_SASS_SRC}`,
             `${uswds}/scss`,
-            `${uswds}/scss/packages`
-          ]
+            `${uswds}/scss/packages`,
+          ],
         })
       )
       .pipe(replace(/\buswds @version\b/g, "based on uswds v" + pkg.version))
@@ -115,46 +114,52 @@ gulp.task("build-sass", function(done) {
 // SVG sprite configuration
 config = {
   shape: {
-    dimension: { // Set maximum dimensions
+    dimension: {
+      // Set maximum dimensions
       maxWidth: 24,
-      maxHeight: 24
+      maxHeight: 24,
     },
     id: {
-      separator: "-"
+      separator: "-",
     },
-    spacing: { // Add padding
-      padding: 0
-    }
+    spacing: {
+      // Add padding
+      padding: 0,
+    },
   },
   mode: {
-    symbol: true // Activate the «symbol» mode
-  }
+    symbol: true, // Activate the «symbol» mode
+  },
 };
 
 gulp.task("build-sprite", function (done) {
-  gulp.src(`${IMG_DEST}/usa-icons/**/*.svg`,
-  {
-    allowEmpty: true
-  })
+  gulp
+    .src(`${IMG_DEST}/usa-icons/**/*.svg`, {
+      allowEmpty: true,
+    })
     .pipe(svgSprite(config))
-    .on('error', function(error) {
+    .on("error", function (error) {
       console.log("There was an error");
     })
     .pipe(gulp.dest(`${IMG_DEST}`))
-    .on('end', function () { done(); });
- });
+    .on("end", function () {
+      done();
+    });
+});
 
- gulp.task("rename-sprite", function (done) {
-  gulp.src(`${IMG_DEST}/symbol/svg/sprite.symbol.svg`,
-  {
-    allowEmpty: true
-  })
+gulp.task("rename-sprite", function (done) {
+  gulp
+    .src(`${IMG_DEST}/symbol/svg/sprite.symbol.svg`, {
+      allowEmpty: true,
+    })
     .pipe(rename(`${IMG_DEST}/sprite.svg`))
     .pipe(gulp.dest(`./`))
-    .on('end', function () { done(); });
- });
+    .on("end", function () {
+      done();
+    });
+});
 
- gulp.task("clean-sprite", function(cb) {
+gulp.task("clean-sprite", function (cb) {
   cb();
   return del.sync(`${IMG_DEST}/symbol`);
 });
@@ -170,7 +175,7 @@ gulp.task(
   )
 );
 
-gulp.task("watch-sass", function() {
+gulp.task("watch-sass", function () {
   gulp.watch(`${PROJECT_SASS_SRC}/**/*.scss`, gulp.series("build-sass"));
 });
 
@@ -178,4 +183,7 @@ gulp.task("watch", gulp.series("build-sass", "watch-sass"));
 
 gulp.task("default", gulp.series("watch"));
 
-gulp.task("svg-sprite", gulp.series("build-sprite", "rename-sprite", "clean-sprite"));
+gulp.task(
+  "svg-sprite",
+  gulp.series("build-sprite", "rename-sprite", "clean-sprite")
+);


### PR DESCRIPTION
## Description
Closes #36. Updates sass import based on [new guidance ](https://github.com/dlmanning/gulp-sass) from gulp-sass and work from @eduxstad in #35. 

## Additional information
Updated formatting so it's consistent. Mainly spacing and quotes.
