### PR TITLE
USWDS-Gulp: Add Github action add-to-project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add all issues to project board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/uswds/projects/8
+          github-token: ${{ secrets.TEST_ORG_RW }}


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines. 

## Title line template: [Title]: Brief description

UI components: For pull requests that impact the look, feel, or functionality of USWDS itself, please open a pull request on the web-design-standards repo (https://github.com/uswds/uswds-site). 

-->

## Description

Related to issue https://github.com/uswds/uswds-team/issues/176

### Purpose
Add the Github [add-to-project](https://github.com/marketplace/actions/add-to-github-projects-beta) action to our repos so that newly opened issues are automatically added to our project board. 

⚠️ This PR uses a 7-day PAT (issued on 06/27) in the encrypted secret for testing purposes. We will re-evaluate the use of this action after that 7 day period is up. If we decide to keep this action, we will update the PAT to one with a longer life. 

### Demo and testing
This action works successfully on my[ personal test repo](https://github.com/amyleadem/issue-template/blob/main/.github/workflows/add-to-project.yml). To test on this repo: 
1. First [open a new issue](https://github.com/amyleadem/issue-template/issues/new/choose)
1. See that the new issue is automatically added to the sample [project board](https://github.com/users/amyleadem/projects/1)

To test on this repo:
1. Merge this PR
2. Open a new issue
3. See if it lands on our project board